### PR TITLE
Set in_reply_to

### DIFF
--- a/.github/workflows/send-email.yaml
+++ b/.github/workflows/send-email.yaml
@@ -55,4 +55,6 @@ jobs:
           from: HaoBIT
           subject: Bulletin Issues Transferred
 
+          in_reply_to: <bulletin-issues-transferred/Capchdo/rss-to-email@haobit.top>
+
           html_body: file://dist/email.html


### PR DESCRIPTION
这样也许收件人那边可把每天的更新集中起来，例如折叠成会话。

参考：GitHub 发的自动邮件有下面这些字段。

```mail
Message-ID: <Capchdo/rss-to-email/pull/1/issue_event/11625354847@github.com>
In-Reply-To: <Capchdo/rss-to-email/pull/1@github.com>
References: <Capchdo/rss-to-email/pull/1@github.com>
Subject: Re: [Capchdo/rss-to-email] Merge upstream (PR #1)
```

（我不完全确定可行，试了才知道）